### PR TITLE
Add FSTBHC and modify some scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,215 +1,764 @@
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
-add_test(NAME basic_c_tests/CI-funptr.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/CI-funptr.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/CI-global.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/CI-global.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/CI-local.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc//CI-local.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/array-constIdx.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array-constIdx.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/array-varIdx.c COMMAND COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array-varIdx.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/array-varIdx2.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array-varIdx2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/branch-call.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/branch-call.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/branch-intra.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/branch-intra.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/constraint-cycle-copy.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/constraint-cycle-copy.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/constraint-cycle-field.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/constraint-cycle-field.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/constraint-cycle-pwc.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/constraint-cycle-pwc.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/field-ptr-arith-constIdx.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/field-ptr-arith-constIdx.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/field-ptr-arith-varIdx.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/field-ptr-arith-varIdx.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/funptr-global.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/funptr-global.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/funptr-nested-call.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/funptr-nested-call.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/funptr-simple.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/funptr-simple.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/funptr-struct.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/funptr-struct.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-array.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-array.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-call-noparam.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-call-noparam.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-call-struct.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-call-struct.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-call-twoparms.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-call-twoparms.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-const-struct.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-const-struct.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-funptr.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-funptr.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-initializer.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-initializer.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-nested-calls.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-nested-calls.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/global-simple.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global-simple.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/heap-indirect.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/heap-indirect.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/heap-linkedlist.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/heap-linkedlist.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/heap-wrapper.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/heap-wrapper.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/int2pointer.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/int2pointer.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/mesa.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/mesa.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/ptr-dereference1.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/ptr-dereference1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/ptr-dereference2.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/ptr-dereference2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/ptr-dereference3.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/ptr-dereference3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/spec-equake.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/spec-equake.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/spec-gap.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/spec-gap.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/spec-mesa.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/spec-mesa.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/spec-parser.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/spec-parser.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/spec-vortex.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/spec-vortex.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-array.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-array.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-assignment-direct.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-assignment-direct.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-assignment-indirect.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-assignment-indirect.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-assignment-nested.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-assignment-nested.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-field-multi-dereference.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-field-multi-dereference.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-incompab-typecast-nested.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-incompab-typecast-nested.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-incompab-typecast.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-incompab-typecast.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-instance-return.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-instance-return.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-nested-1-layer.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-nested-1-layer.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-nested-2-layers.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-nested-2-layers.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-nested-array1.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-nested-array1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-nested-array2.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-nested-array2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME  basic_c_tests/struct-nested-array3.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-nested-array3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME  basic_c_tests/struct-onefld.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-onefld.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-simple.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-simple.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME basic_c_tests/struct-twoflds.c COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct-twoflds.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
 
-#flow-sensitive tests
-add_test(NAME fs_tests/array_alias_1.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array_alias_1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/array_alias_2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array_alias_2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/array_alias_3.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array_alias_3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/array_alias_4.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array_alias_4.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/array_alias_5.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/array_alias_5.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/branch_1.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/branch_1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/branch_2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/branch_2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/branch_3.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/branch_3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/function_pointer.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/function_pointer.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/function_pointer_2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/function_pointer_2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/global_1.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global_1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/global_2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global_2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/global_3.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global_3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/global_4.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global_4.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/global_5.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/global_5.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/pcycle1.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/pcycle1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/pcycle2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/pcycle2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/return.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/return.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/simple_1.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/simple_1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/simple_2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/simple_2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/simple_3.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/simple_3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/strong_update.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/strong_update.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/struct_1.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct_1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/struct_2.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/struct_2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/test-su.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/test-su.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME fs_tests/tt.c COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/tt.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
+# Basic C tests (basic_c_tests/)
+add_test(
+  NAME basic_c_tests/CI-funptr.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/CI-funptr.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/CI-global.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/CI-global.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/CI-local.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/CI-local.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/array-constIdx.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/array-constIdx.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/array-varIdx.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/array-varIdx.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/array-varIdx2.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/array-varIdx2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/branch-call.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/branch-call.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/branch-intra.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/branch-intra.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/constraint-cycle-copy.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/constraint-cycle-copy.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/constraint-cycle-field.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/constraint-cycle-field.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/constraint-cycle-pwc.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/constraint-cycle-pwc.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/field-ptr-arith-constIdx.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/field-ptr-arith-constIdx.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/field-ptr-arith-varIdx.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/field-ptr-arith-varIdx.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/funptr-global.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/funptr-global.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/funptr-nested-call.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/funptr-nested-call.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/funptr-simple.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/funptr-simple.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/funptr-struct.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/funptr-struct.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-array.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-array.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-call-noparam.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-call-noparam.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-call-struct.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-call-struct.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-call-twoparms.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-call-twoparms.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-const-struct.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-const-struct.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-funptr.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-funptr.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-initializer.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-initializer.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-nested-calls.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-nested-calls.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/global-simple.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/global-simple.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/heap-indirect.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/heap-indirect.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/heap-linkedlist.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/heap-linkedlist.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/heap-wrapper.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/heap-wrapper.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/int2pointer.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/int2pointer.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/mesa.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/mesa.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/ptr-dereference1.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/ptr-dereference1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/ptr-dereference2.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/ptr-dereference2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/ptr-dereference3.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/ptr-dereference3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/spec-equake.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/spec-equake.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/spec-gap.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/spec-gap.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/spec-mesa.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/spec-mesa.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/spec-parser.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/spec-parser.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/spec-vortex.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/spec-vortex.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-array.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-array.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-assignment-direct.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-assignment-direct.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-assignment-indirect.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-assignment-indirect.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-assignment-nested.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-assignment-nested.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-field-multi-dereference.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-field-multi-dereference.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-incompab-typecast-nested.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-incompab-typecast-nested.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-incompab-typecast.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-incompab-typecast.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-instance-return.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-instance-return.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-nested-1-layer.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-nested-1-layer.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-nested-2-layers.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-nested-2-layers.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-nested-array1.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-nested-array1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-nested-array2.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-nested-array2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-nested-array3.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-nested-array3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-onefld.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-onefld.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-simple.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-simple.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/struct-twoflds.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-twoflds.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
 
-#context-sensitive tests
-add_test(NAME cs_tests/cs0.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs0.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs1.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs2.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs3.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs4.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs4.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs5.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs5.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs6.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs6.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs7.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs7.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs8.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs8.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs9.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs9.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs10.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs10.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs11.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs11.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs12.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs12.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs13.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs13.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs14.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs14.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs15.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs15.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs16.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs16.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs17.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs17.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs18.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs18.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs19.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs19.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/cs20.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs20.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/funcpoiner.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/funcpoiner.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur0.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur0.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur2.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur3.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur4.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur4.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur5.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur5.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur6.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur6.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur7.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur7.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur8.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur8.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur9.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur9.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME cs_tests/recur10.c COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/recur10.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
+# Flow-sensitive tests (fs_tests/)
+add_test(
+  NAME fs_tests/array_alias_1.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/array_alias_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/array_alias_2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/array_alias_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/array_alias_3.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/array_alias_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/array_alias_4.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/array_alias_4.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/array_alias_5.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/array_alias_5.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/branch_1.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/branch_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/branch_2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/branch_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/branch_3.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/branch_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/function_pointer.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/function_pointer.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/function_pointer_2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/function_pointer_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/global_1.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/global_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/global_2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/global_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/global_3.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/global_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/global_4.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/global_4.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/global_5.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/global_5.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/pcycle1.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/pcycle1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/pcycle2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/pcycle2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/return.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/return.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/simple_1.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/simple_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/simple_2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/simple_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/simple_3.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/simple_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/strong_update.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/strong_update.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/struct_1.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/struct_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/struct_2.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/struct_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/test-su.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/test-su.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fs_tests/tt.c
+  COMMAND wpa -fspta -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fs_tests/tt.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
 
-#memory leak test cases
-#[[
-add_test(NAME mem_leak/malloc0.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc0.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc1.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc2.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc3.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc4.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc4.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc5.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc5.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc6.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc6.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc7.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc7.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc8.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc8.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc9.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc9.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc10.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc10.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc11.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc11.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc12.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc12.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc13.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc13.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc14.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc14.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc15.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc15.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc16.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc16.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc17.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc17.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc18.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc18.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc19.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc19.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc20.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc20.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc21.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc21.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc22.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc22.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc23.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc23.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc24.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc24.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc25.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc25.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc26.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc26.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc27.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc27.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc28.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc28.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc29.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc29.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc30.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc30.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc31.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc31.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc32.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc32.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc33.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc33.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc34.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc34.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc35.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc35.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc36.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc36.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc37.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc37.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc38.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc38.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc39.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc39.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc40.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc40.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc41.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc41.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc42.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc42.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc43.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc43.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc44.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc44.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc45.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc45.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc46.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc46.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc47.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc47.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc48.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc48.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc49.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc49.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc50.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc50.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc51.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc51.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc52.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc52.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc53.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc53.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc54.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc54.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc55.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc55.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc56.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc56.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc57.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc57.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc58.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc58.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc59.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc59.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc60.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc60.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc61.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc61.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc62.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc62.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/malloc63.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/malloc63.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp1.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp1.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp10.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp10.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp11.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp11.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp12.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp12.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp12a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp12a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp13.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp13.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp13a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp13a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp14.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp14.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp14a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp14a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp15.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp15.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp15a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp15a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp1a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp1a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp2.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp2.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp22.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp22.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp2a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp2a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp3.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp3.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp3a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp3a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp4.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp4.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp41.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp41.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp4a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp4a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp5.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp5.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp5a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp5a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp6.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp6.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp6a.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp6a.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME  mem_leak/sp7.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp7.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp8.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp8.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-add_test(NAME mem_leak/sp9.c COMMAND saber -leak -valid-tests -mempar=inter-disjoint -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/sp9.c.bc WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin)
-]]
+# Context-sensitive tests (cs_tests/)
+add_test(
+  NAME cs_tests/cs0.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs0.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs1.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs10.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs10.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs11.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs11.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs12.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs12.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs13.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs13.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs14.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs14.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs15.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs15.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs16.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs16.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs17.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs17.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs18.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs18.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs19.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs19.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs2.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs20.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs20.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs21.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs21.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs3.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs4.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs4.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs5.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs5.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs6.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs6.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs7.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs7.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs8.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs8.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/cs9.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/cs9.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/funcpoiner.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/funcpoiner.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur0.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur0.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur10.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur10.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur2.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur3.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur4.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur4.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur5.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur5.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur6.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur6.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur7.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur7.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur8.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur8.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME cs_tests/recur9.c
+  COMMAND dvf -cxt -print-pts=false -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/cs_tests/recur9.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+
+# Flow-sensitive type-based heap cloning tests
+# (fstbhc_tests/)
+add_test(
+  NAME fstbhc_tests/array1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/array1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/basic1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/basic1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/constructor1.cpp
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/constructor1.cpp.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/field1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/field1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/field2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/field2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/field3.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/field3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/loop.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/loop.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/union.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/union.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/virtual1.cpp
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/virtual1.cpp.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/virtual2.cpp
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/virtual2.cpp.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/virtual3.cpp
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/virtual3.cpp.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/xmalloc1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/xmalloc1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/xmalloc2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/xmalloc2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/xmalloc3.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/xmalloc3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+
+# (fstbhc/fs_tests/)
+add_test(
+  NAME fstbhc_tests/fs_tests/array_alias_1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/array_alias_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/array_alias_2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/array_alias_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/array_alias_3.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/array_alias_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/array_alias_4.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/array_alias_4.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/array_alias_5.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/array_alias_5.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/branch_1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/branch_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/branch_2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/branch_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/branch_3.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/branch_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/function_pointer.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/function_pointer.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/function_pointer_2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/function_pointer_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/global_1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/global_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/global_2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/global_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/global_3.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/global_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/global_4.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/global_4.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/global_5.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/global_5.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/pcycle1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/pcycle1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/simple_1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/simple_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/simple_2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/simple_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/simple_3.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/simple_3.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/strong_update.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/strong_update.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/struct_1.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/struct_1.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME fstbhc_tests/fs_tests/struct_2.c
+  COMMAND wpa -fstbhc -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/fstbhc_tests/fs_tests/struct_2.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ cd SVF
 ```
 
 The following gives the Test-Suite's folders and the corresponding SVF's options for validation.
-| Folder       |  SVF option | Description        |
-|--------------|--------------------|:------------------:|
-|basic_c_tests |   wpa -ander -stat=false | basic test cases for C programs (flow-insensitive and field-sensitive analysis)|
-|basic_cpp_tests | wpa -ander -stat=false | basic test cases for C++ programs (flow-insensitive and field-sensitive analysis) |
-|fs_tests |   wpa -fspta -stat=false | flow-sensitive tests|
-|cs_tests |  dvf -cxt -print-pts=false -stat=false | context-sensitive tests|
-|path_tests |   | path-sensitive tests|
-|complex_tests | wpa -ander -stat=false | complex test cases simplified from real programs|
-|mta |  | multithreaded test cases|
-|mem_leak |   saber -leak -valid-tests -mempar=inter-disjoint -stat=false | memory leak test cases|
-| fstbhc_tests | wpa -fstbhc -stat=false | FSTBHC tests |
-| fstbhc_tests/fs_tests | wpa -fstbhc -stat=false | FSTBHC tests sourced from fs_tests |
+| Folder                |  SVF option                                                 | Description                                                                       |
+|-----------------------|-------------------------------------------------------------|:---------------------------------------------------------------------------------:|
+| basic_c_tests         | wpa -ander -stat=false                                      | basic test cases for C programs (flow-insensitive and field-sensitive analysis)   |
+| basic_cpp_tests       | wpa -ander -stat=false                                      | basic test cases for C++ programs (flow-insensitive and field-sensitive analysis) |
+| fs_tests              | wpa -fspta -stat=false                                      | flow-sensitive tests                                                              |
+| cs_tests              | dvf -cxt -print-pts=false -stat=false                       | context-sensitive tests                                                           |
+| path_tests            |                                                             | path-sensitive tests                                                              |
+| complex_tests         | wpa -ander -stat=false                                      | complex test cases simplified from real programs                                  |
+| mta                   |                                                             | multithreaded test cases                                                          |
+| mem_leak              | saber -leak -valid-tests -mempar=inter-disjoint -stat=false | memory leak test cases                                                            |
+| fstbhc_tests          | wpa -fstbhc -stat=false                                     | FSTBHC tests                                                                      |
+| fstbhc_tests/fs_tests | wpa -fstbhc -stat=false                                     | FSTBHC tests sourced from fs_tests                                                |
 
 To compile the tests in `fstbhc_tests` and `fstbhc_tests/fs_tests`, [ctir Clang](https://github.com/mbarbar/ctir) is required, which SVF's `build.sh` will download.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## How to use Test-Suite
+# How to use Test-Suite
 
 Test-Suite is a micro-benchmark suite designed for validating various static analysis algorithms (particularly pointer analyses and static bug checkers) developed in SVF. It includes around 400 hand-written programs and code snippets. Test-Suite provides flexible and extendable interfaces for users to add their own tests for validating the correctness of different static analyses.
 
@@ -21,5 +21,32 @@ The following gives the Test-Suite's folders and the corresponding SVF's options
 |complex_tests | wpa -ander -stat=false | complex test cases simplified from real programs|
 |mta |  | multithreaded test cases|
 |mem_leak |   saber -leak -valid-tests -mempar=inter-disjoint -stat=false | memory leak test cases|
+| fstbhc_tests | wpa -fstbhc -stat=false | FSTBHC tests |
+| fstbhc_tests/fs_tests | wpa -fstbhc -stat=false | FSTBHC tests sourced from fs_tests |
 
+To compile the tests in `fstbhc_tests` and `fstbhc_tests/fs_tests`, [ctir Clang](https://github.com/mbarbar/ctir) is required, which SVF's `build.sh` will download.
+
+## Scripts
+
+`./generate_bc.sh` builds all test cases in the aforementioned folders into `test_cases_bc`.
+
+`./generate_cmake_test.sh` will produce the `add_test` calls required by CMake and output them to stdout.
+The output can be appended to `CMakeLists.txt` with `>> CMakeLists.txt`.
+It takes two arguments: the directory containing `.c`/`.cpp` test cases, and the command to run the test.
+For example, `./generate_cmake_test.sh basic_c_tests "wpa -ander -stat=false"` will produce:
+```
+add_test(
+  NAME basic_c_tests/CI-funptr.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/CI-funptr.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+  NAME basic_c_tests/CI-global.c
+  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/CI-global.c.bc
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
+)
+add_test(
+...
+...
+```
 

--- a/fstbhc_tests/array1.c
+++ b/fstbhc_tests/array1.c
@@ -1,0 +1,31 @@
+#include "tbhc_aliascheck.h"
+
+typedef struct {
+    int x;
+    void (*myfunction)(float *f, long l);
+} str;
+
+float globalf = 3.33333;
+
+void foo(float *f, long l) {
+    TBHC_NOALIAS(f, &globalf);
+}
+
+void bar(float *f, long l) {
+    TBHC_MUSTALIAS(f, &globalf);
+}
+
+str *spec;
+
+void decode(str *hi) {
+    hi->myfunction = bar;
+}
+
+int main(int argc, char *argv[]) {
+    spec = malloc(5000);
+    decode(&spec[argc]);
+    (*spec[argc].myfunction)(&globalf, 555);
+
+    float localf;
+    foo(&localf, 0);
+}

--- a/fstbhc_tests/basic1.c
+++ b/fstbhc_tests/basic1.c
@@ -1,0 +1,8 @@
+#include "tbhc_aliascheck.h"
+
+int main() {
+    int *p = malloc(sizeof(int));
+    int *q = malloc(sizeof(int));
+    TBHC_NOALIAS(p, q);
+    return 0;
+}

--- a/fstbhc_tests/constructor1.cpp
+++ b/fstbhc_tests/constructor1.cpp
@@ -1,0 +1,32 @@
+#include "tbhc_aliascheck.h"
+
+int *global = nullptr;
+
+class A {
+public:
+    int x;
+
+    A() {
+        foo();
+    }
+
+    virtual void foo() {
+        global = &this->x;
+    }
+};
+
+class B : public A {
+public:
+    B() { }
+
+    // Never called.
+    virtual void foo() override {
+        global = nullptr;
+    }
+};
+
+int main(void) {
+    B *b = new B();
+    TBHC_MAYALIAS(global, &b->x);
+}
+

--- a/fstbhc_tests/field1.c
+++ b/fstbhc_tests/field1.c
@@ -1,0 +1,23 @@
+#include "tbhc_aliascheck.h"
+
+// Same allocation site, same field type
+// but different struct type.
+
+struct S {
+    int f;
+};
+
+struct T {
+    int f;
+};
+
+void *xmalloc(size_t s) {
+    void *v = malloc(s);
+    return v;
+}
+
+int main(int argc, char *argv[]) {
+    struct S *s = xmalloc(sizeof(struct S));
+    struct T *t = xmalloc(sizeof(struct T));
+    TBHC_NOALIAS(&s->f, &t->f);
+}

--- a/fstbhc_tests/field2.c
+++ b/fstbhc_tests/field2.c
@@ -1,0 +1,20 @@
+#include "tbhc_aliascheck.h"
+
+// Same object, different field.
+// (fspta passes too.)
+
+struct S {
+    int f1;
+    int f2;
+    int f3;
+};
+
+int main(int argc, char *argv[]) {
+    struct S *s = malloc(sizeof(struct S));
+    // TBHC_NOALIAS(&s->f1, &s->f2);
+    // ^ Old test. This does not pass on the current FSTBHC
+    // implementation because we treat s the same as &s->f1.
+    // This is sound but somewhat imprecise and makes implementing
+    // the first-field rules easier. It can be improved.
+    TBHC_NOALIAS(&s->f2, &s->f3);
+}

--- a/fstbhc_tests/field3.c
+++ b/fstbhc_tests/field3.c
@@ -1,0 +1,18 @@
+#include "tbhc_aliascheck.h"
+
+// Returns field from function.
+
+struct S {
+    int f;
+};
+
+int *foo(struct S *s) {
+    return &s->f;
+}
+
+int main(void) {
+    struct S *s = malloc(sizeof(struct S));
+    s->f = 300;
+    int *i = foo(s);
+    TBHC_MUSTALIAS(&s->f, i);
+}

--- a/fstbhc_tests/fs_tests/array_alias_1.c
+++ b/fstbhc_tests/fs_tests/array_alias_1.c
@@ -1,0 +1,31 @@
+/*
+ * Array alias in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int *f1;
+	int *f2;
+};
+
+int main() {
+	struct MyStruct s[2];
+	int x, y;
+	s[0].f1 = &x;
+	s[1].f2 = &y;
+
+	// Arrays are treated as a single element.
+	// Different fields have its own points-to set.
+	// Same fields have same points-to set, even they belong
+	// to different elements.
+	TBHC_NOALIAS(s[0].f1, s[0].f2);
+	TBHC_NOALIAS(s[0].f1, s[1].f2);
+	TBHC_MAYALIAS(s[0].f1, s[1].f1);
+
+	s[0].f1 = &y;
+	TBHC_MUSTALIAS(s[0].f1, s[1].f2);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/array_alias_1.c
+++ b/fstbhc_tests/fs_tests/array_alias_1.c
@@ -1,9 +1,4 @@
-/*
- * Array alias in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/fs_tests/array_alias_2.c
+++ b/fstbhc_tests/fs_tests/array_alias_2.c
@@ -1,0 +1,39 @@
+/*
+ * Alias with array
+ * Author: Sen Ye
+ * Date: 06/09/2013
+ */
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int * f1;
+	int * f2;
+	float * f3;
+};
+
+int main() {
+	struct MyStruct s[3];
+	int * p[2];
+	int a,b,c,d;
+	float x,y;
+	s[0].f1 = &a, s[0].f2 = &c, s[0].f3 = &x;
+	s[1].f1 = &b, s[1].f2 = &d, s[1].f3 = &y;
+	p[0] = &c, p[1] = &d;
+
+	// Same fields of different elements in a certain
+	// array are treated as one object.
+	TBHC_MAYALIAS(s[0].f1, s[1].f1);
+	TBHC_MAYALIAS(p[0], s[1].f2);
+	TBHC_MAYALIAS(s[0].f3, &y);
+
+	// Different fields of different elements in a 
+	// certain array are treated as different objects.
+	TBHC_NOALIAS(s[0].f1, s[1].f2);
+	TBHC_NOALIAS(p[1], s[1].f1);
+
+	if (a)
+		s[1].f1 = &c;
+	TBHC_MAYALIAS(s[0].f1, s[1].f2);
+
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/array_alias_2.c
+++ b/fstbhc_tests/fs_tests/array_alias_2.c
@@ -1,8 +1,4 @@
-/*
- * Alias with array
- * Author: Sen Ye
- * Date: 06/09/2013
- */
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/fs_tests/array_alias_3.c
+++ b/fstbhc_tests/fs_tests/array_alias_3.c
@@ -1,0 +1,23 @@
+/*
+ * Array alias in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int *f1;
+	int *f2;
+};
+
+int main() {
+	struct MyStruct s[2];
+	int x, y;
+	s[0].f1 = &x;
+	s[1].f2 = &y;
+
+	s[0].f1 = &y;
+	TBHC_MUSTALIAS(s[0].f1, s[1].f2);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/array_alias_3.c
+++ b/fstbhc_tests/fs_tests/array_alias_3.c
@@ -1,9 +1,4 @@
-/*
- * Array alias in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/fs_tests/array_alias_4.c
+++ b/fstbhc_tests/fs_tests/array_alias_4.c
@@ -1,0 +1,22 @@
+/*
+ * Alias with array
+ * Author: Sen Ye
+ * Date: 06/09/2013
+ */
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int * f1;
+	int * f2;
+};
+
+int main() {
+	struct MyStruct s[2];
+	int a,b,c,d;
+	s[0].f1 = &a, s[0].f2 = &c;//, s[0].f3 = &x;
+
+	if (a)
+		s[1].f1 = &c;
+	TBHC_MAYALIAS(s[0].f1, s[1].f2);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/array_alias_4.c
+++ b/fstbhc_tests/fs_tests/array_alias_4.c
@@ -1,8 +1,4 @@
-/*
- * Alias with array
- * Author: Sen Ye
- * Date: 06/09/2013
- */
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/fs_tests/array_alias_5.c
+++ b/fstbhc_tests/fs_tests/array_alias_5.c
@@ -1,0 +1,24 @@
+/*
+ * Alias with array
+ * Author: Sen Ye
+ * Date: 06/09/2013
+ */
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int * f1;
+	int * f2;
+};
+
+int main() {
+	struct MyStruct s[3];
+	int a,b,c,d;
+	s[0].f1 = &a, s[0].f2 = &c;//, s[0].f3 = &x;
+	s[1].f1 = &b, s[1].f2 = &d;//, s[1].f3 = &y;
+
+	if (a)
+		s[1].f1 = &c;
+	TBHC_MAYALIAS(s[0].f1, s[1].f2);
+
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/array_alias_5.c
+++ b/fstbhc_tests/fs_tests/array_alias_5.c
@@ -1,8 +1,4 @@
-/*
- * Alias with array
- * Author: Sen Ye
- * Date: 06/09/2013
- */
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/fs_tests/branch_1.c
+++ b/fstbhc_tests/fs_tests/branch_1.c
@@ -1,0 +1,19 @@
+/*
+ * Branches for testing flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int main() {
+	int *p, *q;
+	int x, y;
+	if (x)
+		p = &x;
+	else
+		p = &y;
+	q = &y;
+	TBHC_MAYALIAS(p, q);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/branch_1.c
+++ b/fstbhc_tests/fs_tests/branch_1.c
@@ -1,9 +1,4 @@
-/*
- * Branches for testing flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int main() {

--- a/fstbhc_tests/fs_tests/branch_2.c
+++ b/fstbhc_tests/fs_tests/branch_2.c
@@ -1,0 +1,22 @@
+/*
+ * Branches for testing flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int main() {
+	int *p, *q;
+	int x, y;
+	q = &y;
+	if (x) {
+		p = &x;
+		TBHC_NOALIAS(p, q);
+	}
+	else {
+		p = &y;
+		TBHC_MUSTALIAS(p, q);
+	}
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/branch_2.c
+++ b/fstbhc_tests/fs_tests/branch_2.c
@@ -1,9 +1,4 @@
-/*
- * Branches for testing flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int main() {

--- a/fstbhc_tests/fs_tests/branch_3.c
+++ b/fstbhc_tests/fs_tests/branch_3.c
@@ -1,0 +1,25 @@
+/*
+ * Branches for testing flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int main() {
+	int **p, **q;
+	int *x, *y;
+	int x0, y0;
+	if (x0) {
+		p = &x;
+		q = &y;
+		TBHC_NOALIAS(p, q);
+	}
+	else {
+		p = &y;
+		q = &x;
+		TBHC_NOALIAS(p, q);
+	}
+	TBHC_MAYALIAS(p, q);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/branch_3.c
+++ b/fstbhc_tests/fs_tests/branch_3.c
@@ -1,9 +1,4 @@
-/*
- * Branches for testing flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int main() {

--- a/fstbhc_tests/fs_tests/function_pointer.c
+++ b/fstbhc_tests/fs_tests/function_pointer.c
@@ -1,0 +1,30 @@
+/*
+ * Function pointer.
+ * Author: Sen Ye
+ * Date: 10/10/2013
+ */
+#include "tbhc_aliascheck.h"
+
+void func1(int *p, int *q) {
+	// if function pointer solved correctly,
+	// p and q will alias due to CS1
+	TBHC_MUSTALIAS(p,q);
+	*p = *q;
+}
+
+void (*fp)(int*,int*);
+
+int main() {
+	int x, y;
+	int *m, *n;
+	if (x) {
+		m = &x, n = &x;
+		fp = func1;
+		fp(m,n); // CS1
+	}
+	else {
+		m = &x; n = &y;
+//		func1(m,n); // CS2
+	}
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/function_pointer.c
+++ b/fstbhc_tests/fs_tests/function_pointer.c
@@ -1,8 +1,4 @@
-/*
- * Function pointer.
- * Author: Sen Ye
- * Date: 10/10/2013
- */
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 void func1(int *p, int *q) {

--- a/fstbhc_tests/fs_tests/function_pointer_2.c
+++ b/fstbhc_tests/fs_tests/function_pointer_2.c
@@ -1,0 +1,26 @@
+/*
+ * Function pointer.
+ * Author: Sen Ye
+ * Date: 10/10/2013
+ */
+#include "tbhc_aliascheck.h"
+
+void func1(int **p, int **q) {
+	*p = *q;
+}
+
+void (*fp)(int**,int**);
+
+int main() {
+	int o1, o2;
+	int *x, *y;
+	int **m, **n;
+	x = &o1;
+	y = &o2;
+	m = &x;
+	n = &y;
+	fp = func1;
+	fp(m,n);
+	TBHC_MUSTALIAS(x, y);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/function_pointer_2.c
+++ b/fstbhc_tests/fs_tests/function_pointer_2.c
@@ -1,8 +1,4 @@
-/*
- * Function pointer.
- * Author: Sen Ye
- * Date: 10/10/2013
- */
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 void func1(int **p, int **q) {

--- a/fstbhc_tests/fs_tests/global_1.c
+++ b/fstbhc_tests/fs_tests/global_1.c
@@ -1,0 +1,24 @@
+/*
+ * Global pointer in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int x, y; int *p = &x; int *q = &y;
+int **pp = &p; int**qq = &q;
+
+void foo() {
+     TBHC_NOALIAS(*pp, *qq);
+}
+void bar() {
+     qq = &q;
+     q = &x;
+}
+int main() {
+    foo();
+    bar();
+    TBHC_MUSTALIAS(*pp, *qq);
+}
+

--- a/fstbhc_tests/fs_tests/global_1.c
+++ b/fstbhc_tests/fs_tests/global_1.c
@@ -1,9 +1,4 @@
-/*
- * Global pointer in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int x, y; int *p = &x; int *q = &y;

--- a/fstbhc_tests/fs_tests/global_2.c
+++ b/fstbhc_tests/fs_tests/global_2.c
@@ -1,0 +1,31 @@
+/*
+ * Global pointer in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int **pp, **qq;
+int *p, *q;
+int x, y;
+
+void foo() {
+	pp = &p;
+	p = &x;
+	qq = &q;
+	q = &y;
+	TBHC_NOALIAS(*pp, *qq);
+}
+
+void bar() {
+	qq = &q;
+	q = &x;
+}
+
+int main() {
+	foo();
+	bar();
+	TBHC_MUSTALIAS(*pp, *qq);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/global_2.c
+++ b/fstbhc_tests/fs_tests/global_2.c
@@ -1,9 +1,4 @@
-/*
- * Global pointer in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int **pp, **qq;

--- a/fstbhc_tests/fs_tests/global_3.c
+++ b/fstbhc_tests/fs_tests/global_3.c
@@ -1,0 +1,28 @@
+/*
+ * Global pointer in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int **pp, **qq;
+int *p, *q;
+int x;
+
+void foo() {
+	*pp = &x;
+}
+
+void bar() {
+	qq = &q;
+	q = &x;
+}
+
+int main() {
+	pp = &p;
+	foo();
+	bar();
+	TBHC_MUSTALIAS(*pp, *qq);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/global_3.c
+++ b/fstbhc_tests/fs_tests/global_3.c
@@ -1,9 +1,4 @@
-/*
- * Global pointer in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int **pp, **qq;

--- a/fstbhc_tests/fs_tests/global_4.c
+++ b/fstbhc_tests/fs_tests/global_4.c
@@ -1,0 +1,25 @@
+#include "tbhc_aliascheck.h"
+int g;
+int* obj = &g; 
+void Zulu(int**p, int *q);
+
+void Xray(){
+
+	int **x,*b,*w,d;
+	x = &b; 
+	w = &d; 
+	Zulu(x,w);
+	TBHC_NOALIAS(b,w);
+	TBHC_MUSTALIAS(b,&g);
+}
+
+
+void Zulu(int**p,int *q){
+	*p = q;
+	*p = obj;
+}
+
+int main(){
+	Xray();
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/global_4.c
+++ b/fstbhc_tests/fs_tests/global_4.c
@@ -1,3 +1,4 @@
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 int g;
 int* obj = &g; 

--- a/fstbhc_tests/fs_tests/global_5.c
+++ b/fstbhc_tests/fs_tests/global_5.c
@@ -1,0 +1,28 @@
+/*
+ * Global pointer in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int **pp, **qq;
+int *p, *q;
+int x;
+
+void foo() {
+	pp = &p;
+	p = &x;
+}
+
+void bar() {
+	qq = &q;
+	q = &x;
+}
+
+int main() {
+	foo();
+	bar();
+	TBHC_MUSTALIAS(*pp, *qq);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/global_5.c
+++ b/fstbhc_tests/fs_tests/global_5.c
@@ -1,9 +1,4 @@
-/*
- * Global pointer in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int **pp, **qq;

--- a/fstbhc_tests/fs_tests/info.txt
+++ b/fstbhc_tests/fs_tests/info.txt
@@ -1,0 +1,7 @@
+The fs_tests directory in .. except with the calls appropriately updated
+to TBHC_XALIAS macros.
+
+pcycle2 is removed because it is an illegal program.
+
+To build:
+    for f in *.c; do echo $f; clang -I../.. -ctir -emit-llvm -S $f; done

--- a/fstbhc_tests/fs_tests/info.txt
+++ b/fstbhc_tests/fs_tests/info.txt
@@ -1,7 +1,0 @@
-The fs_tests directory in .. except with the calls appropriately updated
-to TBHC_XALIAS macros.
-
-pcycle2 is removed because it is an illegal program.
-
-To build:
-    for f in *.c; do echo $f; clang -I../.. -ctir -emit-llvm -S $f; done

--- a/fstbhc_tests/fs_tests/pcycle1.c
+++ b/fstbhc_tests/fs_tests/pcycle1.c
@@ -1,0 +1,15 @@
+#include "tbhc_aliascheck.h"
+int main(){
+    int ***m,**n,*z,*y,z1,y1;
+
+    m=&n;
+    n=&z;
+    *m=&y;
+    TBHC_MUSTALIAS(n,&y);
+    TBHC_NOALIAS(n,&z);
+    z=&z1;
+    y=&y1;
+    ***m=10;
+    z=**m;
+    TBHC_NOALIAS(z,&z1);
+}

--- a/fstbhc_tests/fs_tests/pcycle1.c
+++ b/fstbhc_tests/fs_tests/pcycle1.c
@@ -1,3 +1,4 @@
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 int main(){
     int ***m,**n,*z,*y,z1,y1;

--- a/fstbhc_tests/fs_tests/simple_1.c
+++ b/fstbhc_tests/fs_tests/simple_1.c
@@ -1,0 +1,18 @@
+/*
+ * Simple program to test flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int main() {
+	int *p, *q;
+	int x, y;
+	p = &x;
+	q = &y;
+	TBHC_NOALIAS(p, q);
+	p = q;
+	TBHC_MUSTALIAS(p, q);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/simple_1.c
+++ b/fstbhc_tests/fs_tests/simple_1.c
@@ -1,9 +1,4 @@
-/*
- * Simple program to test flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int main() {

--- a/fstbhc_tests/fs_tests/simple_2.c
+++ b/fstbhc_tests/fs_tests/simple_2.c
@@ -1,0 +1,21 @@
+/*
+ * Simple program to test flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int main() {
+	int *p, *q, *r;
+	int x, y, z;
+	p = &x;
+	q = &y;
+	r = &z;
+	TBHC_NOALIAS(p, q);
+	p = q;
+	TBHC_MUSTALIAS(p, q);
+	p = r;
+	TBHC_NOALIAS(p, q);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/simple_2.c
+++ b/fstbhc_tests/fs_tests/simple_2.c
@@ -1,9 +1,4 @@
-/*
- * Simple program to test flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int main() {

--- a/fstbhc_tests/fs_tests/simple_3.c
+++ b/fstbhc_tests/fs_tests/simple_3.c
@@ -1,0 +1,21 @@
+/*
+ * Simple program to test flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+int main() {
+	int **p, **q;
+	int *x, *y;
+	int x0, y0;
+	p = &x;
+	q = &y;
+	*p = &x0;
+	*q = &y0;
+	TBHC_NOALIAS(*p, *q);
+	*p = *q;
+	TBHC_MUSTALIAS(*p, *q);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/simple_3.c
+++ b/fstbhc_tests/fs_tests/simple_3.c
@@ -1,9 +1,4 @@
-/*
- * Simple program to test flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 int main() {

--- a/fstbhc_tests/fs_tests/strong_update.c
+++ b/fstbhc_tests/fs_tests/strong_update.c
@@ -1,0 +1,15 @@
+#include "tbhc_aliascheck.h"
+void bar(int***k, int***s){
+
+	*k = *s; 
+
+}
+
+int main(){
+	int *p1,*q1,*r1,*a1,*b1,*c1,q2,a2;
+	int **p = &p1;
+	int **q = &q1;
+	q1 = &q2;
+	bar(&p,&q);
+	TBHC_NOALIAS(p,&p1);
+}

--- a/fstbhc_tests/fs_tests/strong_update.c
+++ b/fstbhc_tests/fs_tests/strong_update.c
@@ -1,3 +1,4 @@
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 void bar(int***k, int***s){
 

--- a/fstbhc_tests/fs_tests/struct_1.c
+++ b/fstbhc_tests/fs_tests/struct_1.c
@@ -1,0 +1,27 @@
+/*
+ * Struct alias in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int *f1;
+	int *f2;
+};
+
+int main() {
+	struct MyStruct s1, s2;
+	int x, y;
+	s1.f1 = &x;
+	s1.f2 = &y;
+	s2.f1 = &y;
+	s2.f2 = &x;
+	TBHC_NOALIAS(s1.f1, s1.f2);
+	TBHC_NOALIAS(s1.f1, s2.f1);
+
+	s1.f1 = &y;
+	TBHC_MUSTALIAS(s1.f1, s2.f1);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/struct_1.c
+++ b/fstbhc_tests/fs_tests/struct_1.c
@@ -1,9 +1,4 @@
-/*
- * Struct alias in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/fs_tests/struct_2.c
+++ b/fstbhc_tests/fs_tests/struct_2.c
@@ -1,0 +1,27 @@
+/*
+ * Struct alias in flow-sensitive analysis.
+ * Author: Sen Ye
+ * Date: 08/11/2013
+ */
+
+#include "tbhc_aliascheck.h"
+
+struct MyStruct {
+	int *f1;
+	int *f2;
+};
+
+int main() {
+	struct MyStruct s1, s2;
+	int x, y;
+	s1.f1 = &x;
+	s1.f2 = &y;
+	s2.f1 = &y;
+	s2.f2 = &x;
+	TBHC_NOALIAS(s1.f1, s1.f2);
+	TBHC_NOALIAS(s1.f1, s2.f1);
+
+	s1.f1 = &y;
+	TBHC_MUSTALIAS(s1.f1, s2.f1);
+	return 0;
+}

--- a/fstbhc_tests/fs_tests/struct_2.c
+++ b/fstbhc_tests/fs_tests/struct_2.c
@@ -1,9 +1,4 @@
-/*
- * Struct alias in flow-sensitive analysis.
- * Author: Sen Ye
- * Date: 08/11/2013
- */
-
+/* Copied from fs_tests/ and modified to use TBHC macros. */
 #include "tbhc_aliascheck.h"
 
 struct MyStruct {

--- a/fstbhc_tests/loop.c
+++ b/fstbhc_tests/loop.c
@@ -1,0 +1,21 @@
+#include "tbhc_aliascheck.h"
+
+// Two objects generated in a loop
+// without an allocation wrapper.
+
+int main(int argc, char *argv[]) {
+    int *i;
+    float *f;
+
+    // Condition doesn't matter; it's static analysis (no opt!).
+    while (argc-- < 2) {
+        void *m = malloc(4);
+        if (argc) {
+            i = m;
+        } else {
+            f = m;
+        }
+    }
+
+    TBHC_NOALIAS(i, f);
+}

--- a/fstbhc_tests/union.c
+++ b/fstbhc_tests/union.c
@@ -1,0 +1,55 @@
+#include "tbhc_aliascheck.h"
+
+struct obstack {
+  unsigned long chunk_size;
+  void *chunk;
+  char *object_base;
+  char *next_free;
+  char *chunk_limit;
+  union
+  {
+    unsigned long i;
+    void *p;
+  } temp;
+  unsigned long alignment_mask;
+  union
+  {
+    void (*plain) (int *);
+    void (*extra) (void *, unsigned long);
+  } chunkfun;
+  void *extra_arg;
+};
+
+struct Tokens {
+  unsigned long n_tok;
+  char **tok;
+  unsigned long *tok_len;
+  struct obstack o_data;
+};
+
+int globali;
+
+void foo(int *i) {
+    TBHC_MUSTALIAS(i, &globali);
+}
+
+void bar(int *i) {
+    TBHC_NOALIAS(i, &globali);
+}
+
+void readtokens0_init(struct Tokens *t) {
+    struct obstack *h = &t->o_data;
+    h->chunkfun.plain = foo;
+    h->chunkfun.plain(&globali);
+    h->chunk_limit = (char *) h->chunk_size;
+}
+
+int main(void) {
+    struct Tokens tok;
+    readtokens0_init(&tok);
+
+    int locali;
+    bar(&locali);
+
+    return 0;
+}

--- a/fstbhc_tests/virtual1.cpp
+++ b/fstbhc_tests/virtual1.cpp
@@ -1,0 +1,30 @@
+#include "tbhc_aliascheck.h"
+
+class A {
+public:
+    virtual void foo(int *x, int *y) {
+        TBHC_NOALIAS(x, y);
+    }
+};
+
+class B : public A {
+public:
+    virtual void foo(int *x, int *y) override {
+        TBHC_NOALIAS(x, y);
+    }
+};
+
+int main(void) {
+    int i, j;
+
+    A *a = new A();
+    // A::foo::x == &i && A::foo::y == &j
+    a->foo(&i, &j);
+
+    B *b = new B();
+    // B::foo::x == &j, B::foo::y == &i
+    // NOALIAS stands because call resolution should
+    // resolve to a single function.
+    b->foo(&j, &i);
+}
+

--- a/fstbhc_tests/virtual2.cpp
+++ b/fstbhc_tests/virtual2.cpp
@@ -1,0 +1,34 @@
+#include "tbhc_aliascheck.h"
+
+class A {
+public:
+    virtual void foo(int *x, int *y) {
+        TBHC_NOALIAS(x, y);
+    }
+};
+
+class B : public A {
+public:
+    virtual void foo(int *x, int *y) override {
+        TBHC_EXPECTEDFAIL_NOALIAS(x, y);
+    }
+};
+
+int main(void) {
+    int i, j;
+
+    A *a = new A();
+    // A::foo::x == &i && A::foo::y == &j
+    a->foo(&i, &j);
+
+    B *b = new B();
+    if (i) a = (A *)b;
+    // A::foo::x == &i, A::foo::y == &j
+    // B::foo::x == &i, B::foo::y == &j
+    a->foo(&i, &j);
+    // B::foo::x == &j, B::foo::y == &i
+    // but from the previous call also...
+    // B::foo::x == &i, B::foo::y == &j
+    b->foo(&j, &i);
+}
+

--- a/fstbhc_tests/virtual3.cpp
+++ b/fstbhc_tests/virtual3.cpp
@@ -1,0 +1,35 @@
+#include "tbhc_aliascheck.h"
+
+// Tests virtual calls in constructors.
+
+// A::A() calls foo(&i, &j); *must* be A::foo.
+// B::B() calls foo(&j, &i); *must* be B::foo.
+
+int i, j;
+
+class A {
+public:
+    A() {
+        foo(&i, &j);
+    }
+
+    virtual void foo(int *x, int *y) {
+        TBHC_NOALIAS(x, y);
+    }
+};
+
+class B : public A {
+public:
+    B() {
+        foo(&j, &i);
+    }
+
+    virtual void foo(int *x, int *y) override {
+        TBHC_NOALIAS(x, y);
+    }
+};
+
+int main(void) {
+    B *b = new B();
+}
+

--- a/fstbhc_tests/xmalloc1.c
+++ b/fstbhc_tests/xmalloc1.c
@@ -1,0 +1,12 @@
+#include "tbhc_aliascheck.h"
+
+void *xmalloc(size_t s) {
+    return malloc(s);
+}
+
+int main() {
+    int *p = xmalloc(sizeof(int));
+    int *q = xmalloc(sizeof(int));
+    TBHC_MAYALIAS(p, q);
+    return 0;
+}

--- a/fstbhc_tests/xmalloc2.c
+++ b/fstbhc_tests/xmalloc2.c
@@ -1,0 +1,12 @@
+#include "tbhc_aliascheck.h"
+
+void *xmalloc(size_t s) {
+    return malloc(s);
+}
+
+int main() {
+    int *p = xmalloc(sizeof(int));
+    float *q = xmalloc(sizeof(float));
+    TBHC_NOALIAS(p, q);
+    return 0;
+}

--- a/fstbhc_tests/xmalloc3.c
+++ b/fstbhc_tests/xmalloc3.c
@@ -1,0 +1,17 @@
+#include "tbhc_aliascheck.h"
+
+void *xmalloc(size_t s) {
+    return malloc(s);
+}
+
+int main() {
+    int *p = xmalloc(sizeof(int));
+    float *q = xmalloc(sizeof(float));
+    int *r = xmalloc(sizeof(int));
+
+    TBHC_NOALIAS(p, q);
+    TBHC_MAYALIAS(p, r);
+    TBHC_NOALIAS(q, r);
+
+    return 0;
+}

--- a/generate_bc.sh
+++ b/generate_bc.sh
@@ -33,8 +33,8 @@ for td in $test_dirs; do
 
   for c_f in "$full_td/"*; do
     ext=${c_f##*.}
-    # Only care about .c/.cpp files.
-    if [ "$ext" != "cpp" -a "$ext" != "c" ]; then
+    # Only care about .c/.cpp files. Check $ext = $f in case filename is c/cpp.
+    if [ \( "$ext" != "cpp" -a "$ext" != "c" \) -o "$ext" = "$f" ]; then
       continue
     fi
 
@@ -55,6 +55,16 @@ for td in $test_dirs; do
     else
       # Definitely = cpp.
       compiler="clang++"
+    fi
+
+    # If the test directory is an fstbhc directory, use ctir Clang.
+    if expr "$td" : "^fstbhc" > /dev/null; then
+      if [ ! -d "$CTIR_DIR" -o ! -r "$CTIR_DIR/$compiler" ]; then
+        echo "$0: expected \$CTIR_DIR (= '$CTIR_DIR') to point to ctir compilers; skipping $c_f"
+        continue
+      fi
+
+      compiler="$CTIR_DIR/$compiler -ctir"
     fi
 
     $compiler -Wno-everything -S -emit-llvm -I"$root" "$c_f" -o "$bc_f"

--- a/generate_bc.sh
+++ b/generate_bc.sh
@@ -1,46 +1,65 @@
-root=$(cd "$(dirname "$0")";pwd)
+#!/bin/sh
+# Generate bitcode for the .c/.cpp tests in $test_dirs.
 
-#check wether the test case bc folder exist 
-if [ -d 'test_cases_bc' ] ; then
-    echo "folder exists!"
-else
-    mkdir "test_cases_bc"
-    cp aliascheck.h test_cases_bc/ 
+test_dirs="
+  basic_c_tests
+  basic_cpp_tests
+  complex_tests
+  cpp_types
+  cs_tests
+  fstbhc_tests
+  fstbhc_tests/fs_tests
+  fs_tests
+  mem_leak
+  mta
+  non_annotated_tests
+  path_tests
+"
+
+root=$(cd "$(dirname "$0")"; pwd)
+bc_dir_name="test_cases_bc"
+# Check whether the test case bc folder exists.
+bc_path="$root/$bc_dir_name"
+if [ ! -d "$bc_path" ] ; then
+  mkdir -p "$bc_path"
 fi
 
-bc_path=$root"/test_cases_bc/"
+for td in $test_dirs; do
+  # Where the resulting bitcode files for this test dir will live.
+  bc_td="$bc_path/$td"
+  mkdir -p "$bc_td"
+  # Full path to the test dir.
+  full_td="$root/$td"
 
-function generate_bc(){
-if [ "X$1" != 'X' ]
-   then
-         cd "$1"
-  fi
-  
-files=`ls`
-for filename in $files;do
-	
-	if [ -d $filename ]
-    	then	
-		generate_bc $filename 
-			
-	else
-		#check wether the file is cpp or c file
-		if [ ${filename##*.} = 'cpp' ] || [ ${filename##*.} = 'c' ]
-	 	then
-        		file_path=$(cd "$(dirname "$filename")";pwd)
-	    		echo $file_path"/"$filename
-			if [ ${filename##*.} = 'cpp' ]
-			then
-        			clang++ -c -stdlib=libc++ -iquote $bc_path -emit-llvm $file_path"/"$filename -o $bc_path$filename".bc" -Wno-everything
-			else
-        			clang -c -iquote $bc_path -emit-llvm $file_path"/"$filename -o $bc_path$filename".bc" -Wno-everything
-			fi
-			opt -mem2reg $bc_path$filename".bc" -o $bc_path$filename".bc"
-		fi
-	
-	fi
+  for c_f in "$full_td/"*; do
+    ext=${c_f##*.}
+    # Only care about .c/.cpp files.
+    if [ "$ext" != "cpp" -a "$ext" != "c" ]; then
+      continue
+    fi
+
+    # The output .bc file name.
+    bc_f="$bc_td/`basename "$c_f"`.bc"
+
+    # If the .bc is newer than the .c/.cpp, then no need to compile.
+    if [ "$bc_f" -nt "$c_f" ]; then
+      continue
+    fi
+
+    echo "$0: Compiling: $c_f"
+    echo "$0:        to: $bc_f"
+
+    compiler=""
+    if [ "$ext" = "c" ]; then
+      compiler="clang"
+    else
+      # Definitely = cpp.
+      compiler="clang++"
+    fi
+
+    $compiler -Wno-everything -S -emit-llvm -I"$root" "$c_f" -o "$bc_f"
+    # ^ created a .ll, let's make it .bc, as the filename suggests.
+    llvm-as "$bc_f" -o "$bc_f"
+    opt -mem2reg "$bc_f" -o "$bc_f"
+  done
 done
-	cd ..
-}
-
-generate_bc

--- a/generate_cmake_test.sh
+++ b/generate_cmake_test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Generates the add_test(...) required by CMake given a
+# directory with tests and the command (minus the actual
+# target .bc).
+
+if [ $# -ne 2 ]; then
+  echo "usage: $0 dir command"
+  exit 1
+fi
+
+dir="$1"
+# Strip trailing '/' so we don't double up.
+dir=`echo "$dir" | sed 's/\/$//'`
+cmd="$2"
+
+root=$(cd "$(dirname "$0")"; pwd)
+cd $root
+bc_dir_name="test_cases_bc"
+
+for f in "$dir/"*; do
+  echo "add_test("
+  echo "  NAME $f"
+  echo "  COMMAND $cmd \${CMAKE_CURRENT_SOURCE_DIR}/$bc_dir_name/$f.bc"
+  echo "  WORKING_DIRECTORY \${PROJECT_SOURCE_DIR}/\${CMAKE_BUILD_TYPE}-build/bin"
+  echo ")"
+done

--- a/generate_cmake_test.sh
+++ b/generate_cmake_test.sh
@@ -18,6 +18,12 @@ cd $root
 bc_dir_name="test_cases_bc"
 
 for f in "$dir/"*; do
+  # Ignore non-.c/.cpp files.
+  ext=${f##*.}
+  if [ \( "$ext" != "c" -a "$ext" != "cpp" \) -o "$ext" = "$f" ]; then
+    continue;
+  fi
+
   echo "add_test("
   echo "  NAME $f"
   echo "  COMMAND $cmd \${CMAKE_CURRENT_SOURCE_DIR}/$bc_dir_name/$f.bc"

--- a/tbhc_aliascheck.h
+++ b/tbhc_aliascheck.h
@@ -1,0 +1,68 @@
+#include "aliascheck.h"
+
+// The code produced by these macros looks like:
+//   call XALIAS(...)
+//   %1 = load ...
+//   ...
+//   %n = load %p
+//   store ... %n-1, ...* %n !ctir !t1
+//   call deref()
+//   %n+1 = load ...
+//   ...
+//   %n+n = load %q
+//   store ... %n+n-1, ...* %n+n !ctir !t2
+//   call deref()
+// We want to test the points-to sets of %n and
+// %n+n after filtering with !t1 and !t2 respectively.
+// Clang producing ctir annotations necessary.
+
+void deref(void) { }
+
+#define TBHC_MUSTALIAS(p, q) {\
+    MUSTALIAS(p, q);\
+    *p = *p;\
+    deref();\
+    *q = *q;\
+    deref();\
+}
+
+#define TBHC_PARTIALALIAS(p, q) {\
+    PARTIALALIAS(p, q);\
+    *p = *p;\
+    deref();\
+    *q = *q;\
+    deref();\
+}
+
+#define TBHC_MAYALIAS(p, q) {\
+    MAYALIAS(p, q);\
+    *p = *p;\
+    deref();\
+    *q = *q;\
+    deref();\
+}
+
+#define TBHC_NOALIAS(p, q) {\
+    NOALIAS(p, q);\
+    *p = *p;\
+    deref();\
+    *q = *q;\
+    deref();\
+}
+
+#define TBHC_EXPECTEDFAIL_MAYALIAS(p, q) {\
+    EXPECTEDFAIL_MAYALIAS(p, q);\
+    *p = *p;\
+    deref();\
+    *q = *q;\
+    deref();\
+}
+
+#define TBHC_EXPECTEDFAIL_NOALIAS(p, q) {\
+    EXPECTEDFAIL_NOALIAS(p, q);\
+    *p = *p;\
+    deref();\
+    *q = *q;\
+    deref();\
+}
+


### PR DESCRIPTION
This PR adds a few things:
* Adds the FSTBHC tests.
* Modifies `generate_bc.sh` quite a bit (almost a rewrite).
    * Some things were in place for generality. For the purpose of this script I think they were unnecessary and made modification difficult (the general search rather than hardcoding directory names, the recursion).
    * Compile with `ctir` when necessary (see PR to SVF-Tools/SVF too).
    * Makes `test_cases_bc/` not flat. Example: given `test_dir1/a.c` and `test_dir2/a.c`, the only compiled file would be `test_cases_bc/a.c.bc`. I changed it so that it keeps directories so you have `test_cases_bc/test_dir1/a.c.bc` and `test_cases_bc/test_dir1/a.c.bc`.
    * Running `generate_bc.sh` will only compile what is necessary: when the `.c`/`.cpp` file is newer than the `.bc` file.
* I added a script to generate the `add_test` calls in the CMake file (`./generate_cmake_test.sh basic_c_tests "wpa -ander -stat=false"` for example will print the necessary CMake lines).

With regards to the CMake file, 2 issues:
* It seems like there is a lot of repetition. Would it be wiser to put things into variables rather than hardcode each time?
* It only contains `basic_c_tests`, `cs_tests`, and `fs_tests` (and now `fstbhc*`). Is that intended?