### PR TITLE
Add option to struct-twoflds test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,9 +273,10 @@ add_test(
   COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-simple.c.bc
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
 )
+# This test relies on first-fields not being treated as the base.
 add_test(
   NAME basic_c_tests/struct-twoflds.c
-  COMMAND wpa -ander -stat=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-twoflds.c.bc
+  COMMAND wpa -ander -stat=false -ff-eq-base=false ${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/basic_c_tests/struct-twoflds.c.bc
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${CMAKE_BUILD_TYPE}-build/bin
 )
 


### PR DESCRIPTION
This is in preparation for setting first-fields equivalent to the base. Once this is accepted, I will make a PR on the SVF repo implementing the option/default setting.