### PR TITLE
Fix test invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,3 +221,23 @@ foreach(file ${diff_tests_cruxbc})
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
 endforeach()
+
+# Performance regression testing small (ctest -R diff-perf-cruxbc-small -VV)
+list(
+  APPEND
+  diff_tests_cruxbc_small
+  libbz2.so.bc
+  htop
+)
+set(cmd "wpa -vfspta -dump-vfg")
+string(REPLACE " " ";" commandtemp ${cmd})
+set(command ${commandtemp})
+foreach(file ${diff_tests_cruxbc_small})
+  file(GLOB filename RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/test_cases_bc/crux-bc/${file}.bc")
+  add_test(
+    NAME diff-perf-cruxbc-small/${filename}
+    COMMAND ${command} ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  #  set_tests_properties(diff-perf-cruxbc/${filename} PROPERTIES PASS_REGULAR_EXPRESSION "0")
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ foreach(filename ${files})
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/diff_tests/diff_tests.sh "wpa -fspta -opt-svfg=false" "wpa -vfspta -opt-svfg=false" ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(diff_tests-fs/fspta-vfspta/${filename} PROPERTIES PASS_REGULAR_EXPRESSION "0")
 endforeach()
 
 
@@ -120,7 +119,6 @@ foreach(folder ${diff_tests_anderson_folders})
       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/diff_tests/diff_tests.sh "wpa -ander -alias-check=false" "wpa -nander -alias-check=false" ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
-    set_tests_properties(diff_tests-ander/ander-nander/${filename} PROPERTIES PASS_REGULAR_EXPRESSION "0")
 
     # read and write ander
     # change file extension to .pre.bc
@@ -222,5 +220,4 @@ foreach(file ${diff_tests_cruxbc})
     COMMAND ${command} ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(diff-perf-cruxbc/${filename} PROPERTIES PASS_REGULAR_EXPRESSION "0")
 endforeach()

--- a/src/diff_tests/diff_tests.cpp
+++ b/src/diff_tests/diff_tests.cpp
@@ -13,14 +13,19 @@ std::string exec_command(const char* cmd)
 {
     std::array<char, 128> buffer;
     std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    FILE * pipe = popen(cmd, "r");
     if (!pipe) 
     {
         throw std::runtime_error("popen() failed!");
     }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) 
+    while (fgets(buffer.data(), buffer.size(), pipe) != nullptr)
     {
         result += buffer.data();
+    }
+    auto res = pclose(pipe);
+    if (res != 0) {
+      std::cout << "Error execution of " << cmd << " failed\n";
+      abort();
     }
     return result;
 }


### PR DESCRIPTION
 Explicitly fail diff_tests if running the cmd failed to detect assertions

Without these changes, tests succeed even though the executed application
failed in the first place.
Require zero-return for executed applications not 0-pattern matching.

If this is merged, this will fail certain test cases, for example the following assertion is triggered often without failing the test case (https://github.com/SVF-tools/SVF/actions/runs/3538322327/jobs/5939060081#step:11:78):

```
svf-ex: /home/runner/work/SVF/SVF/include/SVF-LLVM/IRAnnotator.h:108: void SVF::IRAnnotator::readPAGgepNodes(SVF::SVFIR*): Assertion `idEq && "nodeId is not equal to gepnodeId?"' failed.
```

This should be fixed by somebody more familiar with the code than me.