### PR TITLE
Basic test for some static return functions

### DIFF
--- a/src/basic_cpp_tests/static-return1.cpp
+++ b/src/basic_cpp_tests/static-return1.cpp
@@ -1,0 +1,24 @@
+#include "aliascheck.h"
+#include <cerrno>
+#include <cstdlib>
+
+using namespace std;
+
+int main(int argc, char **argv)
+{
+{  
+  char* p = getenv("HOME");
+  char* q = getenv("HOME");
+
+  MUSTALIAS(p, q);
+}
+
+{
+  int* p = __errno_location();
+  int* q = __errno_location();
+
+  MUSTALIAS(p, q);
+}
+
+  return 0;
+}

--- a/src/basic_cpp_tests/static-return2.cpp
+++ b/src/basic_cpp_tests/static-return2.cpp
@@ -1,0 +1,20 @@
+#include "aliascheck.h"
+#include <ctime>
+
+using namespace std;
+
+int main(int argc, char **argv)
+{
+  time_t time = 0;
+  tm* p1 = gmtime(&time);
+  tm* p2 = gmtime(&time);
+  tm* q1 = localtime(&time);
+  tm* q2 = localtime(&time);
+
+  MAYALIAS(p1, q1);
+  MUSTALIAS(p1, p2);
+  MUSTALIAS(q1, q2);
+
+
+  return 0;
+}


### PR DESCRIPTION
In contribution to the current [discussion](https://github.com/SVF-tools/SVF/pull/1688) about functions that always return the same function, I added two tests to check whether getenv, errno_location, gmtime and localtime return pointers that alias according to SVF. According to the documentation, gmtime and localtime may share the same return object. This is the case in glibc, so i added a test for that too. Although my interpretation of may alias might be off.

I do expect these to fail with the latest version.

Please let me know if there are any issues. 