### PR TITLE
refactor: replace set_value with direct assignment/assertion in 3 ae tests

### DIFF
--- a/src/ae_assert_tests/BASIC_ptr_call2-0.c
+++ b/src/ae_assert_tests/BASIC_ptr_call2-0.c
@@ -1,20 +1,13 @@
 // CHECK: ^unsat$
 #include "stdbool.h"
 extern void svf_assert(bool);
-extern void svf_assert_eq(int, int);
-extern void svf_print(int, char*);
-extern void set_value(int, int, int);
 
-int a (void);
 int c (int);
 
 int main() {
   int y = c(2);
   int x = c(3);
-  int res;
-  set_value(res, 2, 3);
-  svf_print(x, "X");
-  svf_assert_eq(x, res);
+  svf_assert(x >= 2 && x <= 3);
 
   return 0;
 }

--- a/src/ae_assert_tests/INTERVAL_test_19-0.c
+++ b/src/ae_assert_tests/INTERVAL_test_19-0.c
@@ -1,11 +1,9 @@
 #include "stdbool.h"
 extern void svf_assert(bool);
-extern void set_value(int, int, int);
-#include <assert.h>
 
 void foo(int* i) {
     int a = *i % 2;
-    switch (a) 
+    switch (a)
     {
         case 0:
             break;
@@ -19,8 +17,7 @@ void foo(int* i) {
 }
 
 int main() {
-    int i;
-    set_value(i, 1, 1);
+    int i = 1;
     if (i >= 0) {
         foo(&i);
         svf_assert(i % 2 == 0);

--- a/src/ae_assert_tests/LOOP_for_inc-0.c
+++ b/src/ae_assert_tests/LOOP_for_inc-0.c
@@ -1,14 +1,10 @@
 #include "stdbool.h"
 extern void svf_assert(bool);
-extern void svf_assert_eq(int, int);
-extern void set_value(int, int, int);
-extern void svf_print(int, char*);
+
 int main() {
     int i = 0;
     for (i = 0; i < 5; i++) {
         i++;
     }
-    int res;
-    set_value(res, 5, 6);
-    svf_assert_eq(i, res);
+    svf_assert(i >= 5 && i <= 6);
 }


### PR DESCRIPTION

These tests used the set_value external API to set expected intervals, which couples them to a specific external API implementation. Replace with direct assignment (INTERVAL_test_19) or svf_assert with explicit range checks (BASIC_ptr_call2, LOOP_for_inc).