### PR TITLE
Update C++ IR fixtures for LLVM 21 parser

### DIFF
--- a/.github/workflows/Test-Suite.yml
+++ b/.github/workflows/Test-Suite.yml
@@ -7,6 +7,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/Test-Suite.yml
+++ b/.github/workflows/Test-Suite.yml
@@ -29,8 +29,8 @@ jobs:
             sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
             sudo apt-get update
             sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev unzip tar
-            wget https://github.com/SVF-tools/SVF/releases/download/SVF-3.0/llvm-16.0.0-ubuntu24-rtti-x86-64.tar.gz
-            mkdir -p "/opt/llvm" && tar -xf llvm-16.0.0-ubuntu24-rtti-x86-64.tar.gz -C "/opt/llvm" --strip-components 1
+            wget https://github.com/bjjwwang/SVF-LLVM/releases/download/21.1.0/llvm-21.1.0-ubuntu22-rtti-x86-64.tar.gz
+            mkdir -p "/opt/llvm" && tar -xf llvm-21.1.0-ubuntu22-rtti-x86-64.tar.gz -C "/opt/llvm" --strip-components 1
             echo "/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: stash-changes
@@ -45,7 +45,7 @@ jobs:
            git status
            git pull
            bash ./generate_bc.sh
-           git clone https://github.com/bjjwwang/crux-bitcode -b 16.0.6
+           git clone https://github.com/bjjwwang/crux-bitcode -b 21.1.0
            cd crux-bitcode
            rm pkgs.txt
            echo -e "bc\nhtop\ncurl\nbzip2\nunrar\ntmux\nbash" >> pkgs.txt

--- a/test_cases_bc/basic_cpp_tests/abstract.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/abstract.cpp.bc
@@ -212,7 +212,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -222,7 +222,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/array-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/array-1.cpp.bc
@@ -208,7 +208,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/array-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/array-2.cpp.bc
@@ -210,7 +210,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/array-3.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/array-3.cpp.bc
@@ -210,7 +210,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/constructor-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/constructor-1.cpp.bc
@@ -196,7 +196,7 @@ entry:
   %this1 = load ptr, ptr %this.addr, align 8
   %0 = load ptr, ptr %i.addr, align 8
   call void @_ZN1AC2EPi(ptr noundef nonnull align 8 dereferenceable(8) %this1, ptr noundef %0)
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   %1 = load ptr, ptr %i.addr, align 8
   %vtable = load ptr, ptr %this1, align 8
   %vfn = getelementptr inbounds ptr, ptr %vtable, i64 0
@@ -213,7 +213,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %i, ptr %i.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %0 = load ptr, ptr %i.addr, align 8
   %vtable = load ptr, ptr %this1, align 8
   %vfn = getelementptr inbounds ptr, ptr %vtable, i64 0

--- a/test_cases_bc/basic_cpp_tests/constructor-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/constructor-2.cpp.bc
@@ -216,7 +216,7 @@ entry:
   %this1 = load ptr, ptr %this.addr, align 8
   %0 = load ptr, ptr %i.addr, align 8
   call void @_ZN1AC2EPi(ptr noundef nonnull align 8 dereferenceable(8) %this1, ptr noundef %0)
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   %1 = load ptr, ptr %i.addr, align 8
   call void @_Z1gP1APi(ptr noundef %this1, ptr noundef %1)
   ret void
@@ -230,7 +230,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %i, ptr %i.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %0 = load ptr, ptr %i.addr, align 8
   call void @_Z1gP1APi(ptr noundef %this1, ptr noundef %0)
   ret void

--- a/test_cases_bc/basic_cpp_tests/deque-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/deque-1.cpp.bc
@@ -362,7 +362,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/deque-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/deque-2.cpp.bc
@@ -362,7 +362,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/deque-3.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/deque-3.cpp.bc
@@ -355,7 +355,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1457,7 +1457,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/deque-4.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/deque-4.cpp.bc
@@ -355,7 +355,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1456,7 +1456,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/destructor-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/destructor-1.cpp.bc
@@ -245,7 +245,7 @@ entry:
   %this1 = load ptr, ptr %this.addr, align 8
   %0 = load ptr, ptr %i.addr, align 8
   call void @_ZN1AC2EPi(ptr noundef nonnull align 8 dereferenceable(16) %this1, ptr noundef %0)
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   %bptr = getelementptr inbounds %class.B, ptr %this1, i32 0, i32 1
   %1 = load ptr, ptr %i.addr, align 8
   store ptr %1, ptr %bptr, align 8
@@ -265,7 +265,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %i, ptr %i.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %aptr = getelementptr inbounds %class.A, ptr %this1, i32 0, i32 1
   %0 = load ptr, ptr %i.addr, align 8
   store ptr %0, ptr %aptr, align 8
@@ -278,7 +278,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   %vtable = load ptr, ptr %this1, align 8
   %vfn = getelementptr inbounds ptr, ptr %vtable, i64 2
   %0 = load ptr, ptr %vfn, align 8
@@ -327,7 +327,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %vtable = load ptr, ptr %this1, align 8
   %vfn = getelementptr inbounds ptr, ptr %vtable, i64 2
   %0 = load ptr, ptr %vfn, align 8

--- a/test_cases_bc/basic_cpp_tests/destructor-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/destructor-2.cpp.bc
@@ -258,7 +258,7 @@ entry:
   %this1 = load ptr, ptr %this.addr, align 8
   %0 = load ptr, ptr %i.addr, align 8
   call void @_ZN1AC2EPi(ptr noundef nonnull align 8 dereferenceable(16) %this1, ptr noundef %0)
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   %bptr = getelementptr inbounds %class.B, ptr %this1, i32 0, i32 1
   %1 = load ptr, ptr %i.addr, align 8
   store ptr %1, ptr %bptr, align 8
@@ -278,7 +278,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %i, ptr %i.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %aptr = getelementptr inbounds %class.A, ptr %this1, i32 0, i32 1
   %0 = load ptr, ptr %i.addr, align 8
   store ptr %0, ptr %aptr, align 8
@@ -291,7 +291,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   invoke void @_Z1gP1A(ptr noundef %this1)
           to label %invoke.cont unwind label %terminate.lpad
 
@@ -337,7 +337,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   invoke void @_Z1gP1A(ptr noundef %this1)
           to label %invoke.cont unwind label %terminate.lpad
 

--- a/test_cases_bc/basic_cpp_tests/diamond-inheritance.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/diamond-inheritance.cpp.bc
@@ -250,9 +250,9 @@ entry:
   call void @_ZN1BC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #5
   %0 = getelementptr inbounds i8, ptr %this1, i64 8
   call void @_ZN1CC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %0) #5
-  store ptr getelementptr inbounds ({ [3 x ptr], [3 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr], [3 x ptr] }, ptr @_ZTV1D, i32 0, i32 0, i32 2), ptr %this1, align 8
   %add.ptr = getelementptr inbounds i8, ptr %this1, i64 8
-  store ptr getelementptr inbounds ({ [3 x ptr], [3 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 1, i32 2), ptr %add.ptr, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr], [3 x ptr] }, ptr @_ZTV1D, i32 0, i32 1, i32 2), ptr %add.ptr, align 8
   ret void
 }
 
@@ -263,7 +263,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #5
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -274,7 +274,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #5
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1C, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1C, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -318,7 +318,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/dynamic_cast-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/dynamic_cast-1.cpp.bc
@@ -227,7 +227,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -240,7 +240,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/forward_list-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/forward_list-1.cpp.bc
@@ -307,7 +307,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/forward_list-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/forward_list-2.cpp.bc
@@ -313,7 +313,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/forward_list-3.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/forward_list-3.cpp.bc
@@ -299,7 +299,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -805,7 +805,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/forward_list-4.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/forward_list-4.cpp.bc
@@ -305,7 +305,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -823,7 +823,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/func-ptr-in-class.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/func-ptr-in-class.cpp.bc
@@ -263,7 +263,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/global-obj-in-array.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/global-obj-in-array.cpp.bc
@@ -188,7 +188,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store i32 %d, ptr %d.addr, align 4
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %data = getelementptr inbounds %class.A, ptr %this1, i32 0, i32 1
   %0 = load i32, ptr %d.addr, align 4
   store i32 %0, ptr %data, align 8

--- a/test_cases_bc/basic_cpp_tests/list-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/list-1.cpp.bc
@@ -317,7 +317,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/list-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/list-2.cpp.bc
@@ -304,7 +304,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/map-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/map-1.cpp.bc
@@ -419,7 +419,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -684,7 +684,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1872,7 +1872,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/map-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/map-2.cpp.bc
@@ -418,7 +418,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/member-variable.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/member-variable.cpp.bc
@@ -243,7 +243,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -255,7 +255,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %a, ptr %a.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   %_a = getelementptr inbounds %class.B, ptr %this1, i32 0, i32 1
   %0 = load ptr, ptr %a.addr, align 8
   store ptr %0, ptr %_a, align 8

--- a/test_cases_bc/basic_cpp_tests/namespace.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/namespace.cpp.bc
@@ -210,7 +210,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1n1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTVN1n1BE, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTVN1n1BE, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -220,7 +220,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTVN1n1AE, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTVN1n1AE, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/pwc.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/pwc.cpp.bc
@@ -234,7 +234,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/queue-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/queue-1.cpp.bc
@@ -381,7 +381,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1534,7 +1534,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/queue-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/queue-2.cpp.bc
@@ -389,7 +389,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/set-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/set-1.cpp.bc
@@ -381,7 +381,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store i32 %i, ptr %i.addr, align 4
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %data = getelementptr inbounds %class.A, ptr %this1, i32 0, i32 1
   %0 = load i32, ptr %i.addr, align 4
   store i32 %0, ptr %data, align 8
@@ -1494,7 +1494,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   %data = getelementptr inbounds %class.A, ptr %this1, i32 0, i32 1
   %1 = load ptr, ptr %.addr, align 8
   %data2 = getelementptr inbounds %class.A, ptr %1, i32 0, i32 1

--- a/test_cases_bc/basic_cpp_tests/set-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/set-2.cpp.bc
@@ -375,7 +375,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/single-inheritance-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/single-inheritance-1.cpp.bc
@@ -204,7 +204,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -214,7 +214,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/single-inheritance-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/single-inheritance-2.cpp.bc
@@ -217,7 +217,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -228,7 +228,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/single-inheritance-3.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/single-inheritance-3.cpp.bc
@@ -218,7 +218,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -228,7 +228,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/single-inheritance-4.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/single-inheritance-4.cpp.bc
@@ -204,7 +204,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -214,7 +214,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/stack-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/stack-1.cpp.bc
@@ -383,7 +383,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1536,7 +1536,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/stack-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/stack-2.cpp.bc
@@ -386,7 +386,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/unordered_map-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/unordered_map-1.cpp.bc
@@ -461,7 +461,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/unordered_map-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/unordered_map-2.cpp.bc
@@ -460,7 +460,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/unordered_set-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/unordered_set-1.cpp.bc
@@ -463,7 +463,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/vector-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/vector-1.cpp.bc
@@ -321,7 +321,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -774,7 +774,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1350,7 +1350,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/vector-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/vector-2.cpp.bc
@@ -325,7 +325,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/vector-3.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/vector-3.cpp.bc
@@ -330,7 +330,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -809,7 +809,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -1370,7 +1370,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   store ptr %0, ptr %.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/vector-4.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/vector-4.cpp.bc
@@ -335,7 +335,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/virtual-call-simple.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/virtual-call-simple.cpp.bc
@@ -86,7 +86,7 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1KC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1F, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1F, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -123,7 +123,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1K, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1K, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/virtual-diamond-inheritance-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/virtual-diamond-inheritance-2.cpp.bc
@@ -78,7 +78,7 @@ $_ZTV1A = comdat any
 @global_obj_l2 = dso_local global i32 0, align 4
 @global_ptr_l2 = dso_local global ptr @global_obj_l2, align 8
 @_ZTV1D = linkonce_odr dso_local unnamed_addr constant { [11 x ptr], [9 x ptr] } { [11 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZTI1D, ptr @_ZN1A2f1EPi, ptr @_ZN1A2f2EPi, ptr @_ZN1B2g1EPi, ptr @_ZN1B2g2EPi, ptr @_ZN1D2l1EPi, ptr @_ZN1D2l2EPi], [9 x ptr] [ptr inttoptr (i64 -8 to ptr), ptr inttoptr (i64 -8 to ptr), ptr inttoptr (i64 -8 to ptr), ptr inttoptr (i64 -8 to ptr), ptr @_ZTI1D, ptr null, ptr null, ptr @_ZN1C2h1EPi, ptr @_ZN1C2h2EPi] }, comdat, align 8
-@_ZTT1D = linkonce_odr unnamed_addr constant [7 x ptr] [ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr] }, ptr @_ZTC1D0_1B, i32 0, inrange i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr] }, ptr @_ZTC1D0_1B, i32 0, inrange i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr], [6 x ptr] }, ptr @_ZTC1D8_1C, i32 0, inrange i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr], [6 x ptr] }, ptr @_ZTC1D8_1C, i32 0, inrange i32 1, i32 4), ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 0, i32 5), ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 1, i32 5)], comdat, align 8
+@_ZTT1D = linkonce_odr unnamed_addr constant [7 x ptr] [ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr] }, ptr @_ZTC1D0_1B, i32 0, i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr] }, ptr @_ZTC1D0_1B, i32 0, i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr], [6 x ptr] }, ptr @_ZTC1D8_1C, i32 0, i32 0, i32 5), ptr getelementptr inbounds ({ [9 x ptr], [6 x ptr] }, ptr @_ZTC1D8_1C, i32 0, i32 1, i32 4), ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, i32 0, i32 5), ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, i32 1, i32 5)], comdat, align 8
 @_ZTC1D0_1B = linkonce_odr dso_local unnamed_addr constant { [9 x ptr] } { [9 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZTI1B, ptr @_ZN1A2f1EPi, ptr @_ZN1A2f2EPi, ptr @_ZN1B2g1EPi, ptr @_ZN1B2g2EPi] }, comdat, align 8
 @_ZTVN10__cxxabiv121__vmi_class_type_infoE = external global ptr
 @_ZTS1B = linkonce_odr dso_local constant [3 x i8] c"1B\00", comdat, align 1
@@ -343,10 +343,10 @@ entry:
   call void @_ZN1BC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1, ptr noundef getelementptr inbounds ([7 x ptr], ptr @_ZTT1D, i64 0, i64 1)) #5
   %0 = getelementptr inbounds i8, ptr %this1, i64 8
   call void @_ZN1CC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %0, ptr noundef getelementptr inbounds ([7 x ptr], ptr @_ZTT1D, i64 0, i64 3)) #5
-  store ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 0, i32 5), ptr %this1, align 8
-  store ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 0, i32 5), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, i32 0, i32 5), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, i32 0, i32 5), ptr %this1, align 8
   %add.ptr = getelementptr inbounds i8, ptr %this1, i64 8
-  store ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, inrange i32 1, i32 5), ptr %add.ptr, align 8
+  store ptr getelementptr inbounds ({ [11 x ptr], [9 x ptr] }, ptr @_ZTV1D, i32 0, i32 1, i32 5), ptr %add.ptr, align 8
   ret void
 }
 
@@ -356,7 +356,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/virtual-inheritance-1.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/virtual-inheritance-1.cpp.bc
@@ -29,7 +29,7 @@ $_ZTV1A = comdat any
 @global_obj = dso_local global i32 0, align 4
 @global_ptr = dso_local global ptr @global_obj, align 8
 @_ZTV1B = linkonce_odr dso_local unnamed_addr constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr null, ptr null, ptr @_ZTI1B, ptr @_ZN1A1fEPi] }, comdat, align 8
-@_ZTT1B = linkonce_odr unnamed_addr constant [2 x ptr] [ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4), ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4)], comdat, align 8
+@_ZTT1B = linkonce_odr unnamed_addr constant [2 x ptr] [ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4), ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4)], comdat, align 8
 @_ZTVN10__cxxabiv121__vmi_class_type_infoE = external global ptr
 @_ZTS1B = linkonce_odr dso_local constant [3 x i8] c"1B\00", comdat, align 1
 @_ZTVN10__cxxabiv117__class_type_infoE = external global ptr
@@ -217,8 +217,8 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #7
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4), ptr %this1, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4), ptr %this1, align 8
   ret void
 }
 
@@ -228,7 +228,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/virtual-inheritance-2.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/virtual-inheritance-2.cpp.bc
@@ -39,7 +39,7 @@ $_ZTI1B = comdat any
 @_ZTS1A = linkonce_odr dso_local constant [3 x i8] c"1A\00", comdat, align 1
 @_ZTI1A = linkonce_odr dso_local constant { ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 2), ptr @_ZTS1A }, comdat, align 8
 @_ZTV1B = linkonce_odr dso_local unnamed_addr constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr null, ptr null, ptr @_ZTI1B, ptr @_ZN1B1fEPi] }, comdat, align 8
-@_ZTT1B = linkonce_odr unnamed_addr constant [2 x ptr] [ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4), ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4)], comdat, align 8
+@_ZTT1B = linkonce_odr unnamed_addr constant [2 x ptr] [ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4), ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4)], comdat, align 8
 @_ZTVN10__cxxabiv121__vmi_class_type_infoE = external global ptr
 @_ZTS1B = linkonce_odr dso_local constant [3 x i8] c"1B\00", comdat, align 1
 @_ZTI1B = linkonce_odr dso_local constant { ptr, ptr, i32, i32, ptr, i64 } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv121__vmi_class_type_infoE, i64 2), ptr @_ZTS1B, i32 0, i32 1, ptr @_ZTI1A, i64 -8189 }, comdat, align 8
@@ -222,7 +222,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 
@@ -233,8 +233,8 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4), ptr %this1, align 8
-  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 4), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 4), ptr %this1, align 8
   ret void
 }
 

--- a/test_cases_bc/basic_cpp_tests/virtual-inheritance-3.cpp.bc
+++ b/test_cases_bc/basic_cpp_tests/virtual-inheritance-3.cpp.bc
@@ -41,7 +41,7 @@ $_ZTV1A = comdat any
 @global_float_obj = dso_local global float 0.000000e+00, align 4
 @global_float_ptr = dso_local global ptr @global_float_obj, align 8
 @_ZTV1B = linkonce_odr dso_local unnamed_addr constant { [7 x ptr] } { [7 x ptr] [ptr null, ptr null, ptr null, ptr null, ptr @_ZTI1B, ptr @_ZN1B1fEPi, ptr @_ZN1B1gEPf] }, comdat, align 8
-@_ZTT1B = linkonce_odr unnamed_addr constant [2 x ptr] [ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 5), ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 5)], comdat, align 8
+@_ZTT1B = linkonce_odr unnamed_addr constant [2 x ptr] [ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 5), ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 5)], comdat, align 8
 @_ZTVN10__cxxabiv121__vmi_class_type_infoE = external global ptr
 @_ZTS1B = linkonce_odr dso_local constant [3 x i8] c"1B\00", comdat, align 1
 @_ZTVN10__cxxabiv117__class_type_infoE = external global ptr
@@ -237,8 +237,8 @@ entry:
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
   call void @_ZN1AC2Ev(ptr noundef nonnull align 8 dereferenceable(8) %this1) #8
-  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 5), ptr %this1, align 8
-  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, inrange i32 0, i32 5), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 5), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_ZTV1B, i32 0, i32 0, i32 5), ptr %this1, align 8
   ret void
 }
 
@@ -248,7 +248,7 @@ entry:
   %this.addr = alloca ptr, align 8
   store ptr %this, ptr %this.addr, align 8
   %this1 = load ptr, ptr %this.addr, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, inrange i32 0, i32 2), ptr %this1, align 8
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV1A, i32 0, i32 0, i32 2), ptr %this1, align 8
   ret void
 }
 


### PR DESCRIPTION
## Summary

LLVM 21 rejects several older textual IR forms used by the checked-in C++ `.bc` fixtures in the SVF Test-Suite.

This PR updates those fixtures to LLVM 21-compatible textual IR so the suite runs cleanly on a clean LLVM 21 host.

## What changed

- rewrite stale textual GEP forms in `test_cases_bc/basic_cpp_tests/*.bc`
- remove obsolete `inrange` operand forms rejected by LLVM 21's IR parser

These are mechanical fixture updates only. No semantic change to the tests is intended.

## Validation

Validated together with the corresponding SVF LLVM 21 changes:

- clean-host standalone Test-Suite run: `1528 / 1528` passed

## Commit

- `e24103a` `Update C++ IR fixtures for LLVM 21 parser`
