### PR TITLE
Switch generate_bc + crux-bitcode to LLVM 21.1.0

### DIFF
--- a/.github/workflows/Test-Suite.yml
+++ b/.github/workflows/Test-Suite.yml
@@ -29,8 +29,8 @@ jobs:
             sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
             sudo apt-get update
             sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev unzip tar
-            wget https://github.com/SVF-tools/SVF/releases/download/SVF-3.0/llvm-16.0.0-ubuntu24-rtti-x86-64.tar.gz
-            mkdir -p "/opt/llvm" && tar -xf llvm-16.0.0-ubuntu24-rtti-x86-64.tar.gz -C "/opt/llvm" --strip-components 1
+            wget https://github.com/bjjwwang/SVF-LLVM/releases/download/21.1.0/llvm-21.1.0-ubuntu22-rtti-x86-64.tar.gz
+            mkdir -p "/opt/llvm" && tar -xf llvm-21.1.0-ubuntu22-rtti-x86-64.tar.gz -C "/opt/llvm" --strip-components 1
             echo "/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: stash-changes
@@ -45,7 +45,7 @@ jobs:
            git status
            git pull
            bash ./generate_bc.sh
-           git clone https://github.com/bjjwwang/crux-bitcode -b 16.0.6
+           git clone https://github.com/bjjwwang/crux-bitcode -b 21.1.0
            cd crux-bitcode
            rm pkgs.txt
            echo -e "bc\nhtop\ncurl\nbzip2\nunrar\ntmux\nbash" >> pkgs.txt


### PR DESCRIPTION
Switch the Linux build of `Test-Suite.yml` from LLVM 16 to LLVM 21.1.0 end-to-end.

**`env-setup`**: replace `SVF-3.0/llvm-16.0.0-ubuntu24-rtti-x86-64.tar.gz` with `bjjwwang/SVF-LLVM/21.1.0/llvm-21.1.0-ubuntu22-rtti-x86-64.tar.gz`, so `generate_bc.sh` emits LLVM 21 bitcode. The `ubuntu22-rtti` tarball runs cleanly on the `ubuntu-24.04` runner (glibc 2.39 is ABI-backward-compatible with the tarball's 2.35).

**`generate-bcs`**: clone `bjjwwang/crux-bitcode` at `master` (now has the `-v VERSION` flag introduced in commit 1c09fd8) and pass `-v 21.1.0`, which pulls `wangjiaweiuts/crux-bitcode:21.1.0`. The gclang/get-bc pipeline inside that image emits LLVM 21 bitcode.

Net effect: every `.bc` file committed to `test_cases_bc/` will now be LLVM 21, matching the SVF-LLVM 21.1.0 release.